### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/pages/Flutter/methods/localPeer.mdx
+++ b/pages/Flutter/methods/localPeer.mdx
@@ -134,7 +134,7 @@ localPeer.on("metadata-updated", () => {
 });
 
 localPeer.once("stream-available", (data) => {
-  print("Remote Peer stream is avaialble.");
+  print("Remote Peer stream is available.");
 });
 
 localPeer.off("stream-closed", () => {

--- a/pages/Flutter/methods/room.mdx
+++ b/pages/Flutter/methods/room.mdx
@@ -185,7 +185,7 @@ Function `closeStreamOfLabel` will close a particular stream of remote peers in 
   headers={["Params", "Type", "Description", "Return Type"]}
   options={[
     [
-      "lables | peerIds(optional)",
+      "labels | peerIds(optional)",
       "Label of the stream | PeerIds of the remote peers, if not provided, it will close the stream of all the remote peers",
       "close a particular stream of remote peers in the room",
       "void",

--- a/pages/Javascript/methods/localPeer.mdx
+++ b/pages/Javascript/methods/localPeer.mdx
@@ -142,7 +142,7 @@ localPeer.on("metadata-updated", () => {
 });
 
 localPeer.once("stream-available", (data) => {
-  console.log("Remote Peer stream is avaialble.");
+  console.log("Remote Peer stream is available.");
 
 });
 

--- a/pages/Javascript/methods/room.mdx
+++ b/pages/Javascript/methods/room.mdx
@@ -206,7 +206,7 @@ Function `closeStreamOfLabel` will close a particular stream of remote peers in 
 <OptionTable
     headers={["Params","Type","Description" , 'Return Type']}
   options={[
-    ["lables | peerIds(optional)",
+    ["labels | peerIds(optional)",
     "Label of the stream | PeerIds of the remote peers, if not provided, it will close the stream of all the remote peers",
       "close a particular stream of remote peers in the room",
       'void'

--- a/pages/Kotlin/methods/localPeer.mdx
+++ b/pages/Kotlin/methods/localPeer.mdx
@@ -134,7 +134,7 @@ localPeer.on("metadata-updated", () => {
 });
 
 localPeer.once("stream-available", (data) => {
-  print("Remote Peer stream is avaialble.");
+  print("Remote Peer stream is available.");
 });
 
 localPeer.off("stream-closed", () => {

--- a/pages/Kotlin/methods/room.mdx
+++ b/pages/Kotlin/methods/room.mdx
@@ -190,7 +190,7 @@ Function `closeStreamOfLabel` will close a particular stream of remote peers in 
   headers={["Params", "Type", "Description", "Return Type"]}
   options={[
     [
-      "lables | peerIds(optional)",
+      "labels | peerIds(optional)",
       "Label of the stream | PeerIds of the remote peers, if not provided, it will close the stream of all the remote peers",
       "close a particular stream of remote peers in the room",
       "void",


### PR DESCRIPTION
This PR corrects various typographical errors in documentation files related to the `localPeer` and `room` methods across Flutter, JavaScript, and Kotlin implementations. The changes improve readability and accuracy in method descriptions and console log statements.

#### **Changes made:**  
- Fixed avaialble → available
- Corrected lables → labels

---

### **Files Updated**  
- `pages/Flutter/methods/localPeer.mdx`  
- `pages/Flutter/methods/room.mdx`  
- `pages/Javascript/methods/localPeer.mdx`  
- `pages/Javascript/methods/room.mdx`  
- `pages/Kotlin/methods/localPeer.mdx`  
- `pages/Kotlin/methods/room.mdx`  
